### PR TITLE
[WIP] Fix empty line leftovers

### DIFF
--- a/scalafix/input/src/main/scala/fix/alreadysorted.scala
+++ b/scalafix/input/src/main/scala/fix/alreadysorted.scala
@@ -1,0 +1,16 @@
+/*
+ rule = SortImports
+ SortImports.blocks = [
+ "java",
+ "scala",
+ ]
+ */
+import java.math.BigInteger
+import java.util.Map
+
+import scala.collection._
+import scala.util._
+
+object AlreadySorted {
+  // Add code that needs fixing here.
+}

--- a/scalafix/input/src/main/scala/fix/noimports.scala
+++ b/scalafix/input/src/main/scala/fix/noimports.scala
@@ -1,0 +1,10 @@
+/*
+ rule = SortImports
+ SortImports.blocks = [
+ "java",
+ "scala",
+ ]
+ */
+object NoImports {
+  // Add code that needs fixing here.
+}

--- a/scalafix/output/src/main/scala/fix/alreadysorted.scala
+++ b/scalafix/output/src/main/scala/fix/alreadysorted.scala
@@ -1,0 +1,9 @@
+import java.math.BigInteger
+import java.util.Map
+
+import scala.collection._
+import scala.util._
+
+object AlreadySorted {
+  // Add code that needs fixing here.
+}

--- a/scalafix/output/src/main/scala/fix/noimports.scala
+++ b/scalafix/output/src/main/scala/fix/noimports.scala
@@ -1,0 +1,3 @@
+object NoImports {
+  // Add code that needs fixing here.
+}

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.2.8


### PR DESCRIPTION
We only remove the imports, not the empty lines in-between. So those stay and end up at the bottom of the sorted import block.