### PR TITLE
fix handling of import lists, closes #9

### DIFF
--- a/scalafix/input/src/main/scala/fix/importlist.scala
+++ b/scalafix/input/src/main/scala/fix/importlist.scala
@@ -5,10 +5,10 @@
  "scala"
  ]
  */
+import scala.collection._, scala.util._
+
 import java.math.BigInteger
 import java.util.Map
-
-import scala.collection._, scala.util._
 
 object ImportList {
   // Add code that needs fixing here.

--- a/scalafix/rules/src/main/scala/fix/Sortimports.scala
+++ b/scalafix/rules/src/main/scala/fix/Sortimports.scala
@@ -33,7 +33,7 @@ class SortImports(config: SortImportsConfig) extends SemanticRule("SortImports")
 
     // Traverse full code tree. Stop when import branches are found and add them to last list in buf
     // If an empty line is found add an empty list to buf
-    val buf: ListBuffer[ListBuffer[Tree]] = ListBuffer(ListBuffer.empty)
+    val buf: ListBuffer[ListBuffer[Import]] = ListBuffer(ListBuffer.empty)
     val traverser: Traverser = new Traverser {
       override def apply(tree: Tree): Unit = tree match {
         case x: Import =>
@@ -47,7 +47,7 @@ class SortImports(config: SortImportsConfig) extends SemanticRule("SortImports")
     traverser(doc.tree)
 
     // Contains groups of imports
-    val unsorted: ListBuffer[ListBuffer[Tree]] = buf
+    val unsorted: ListBuffer[ListBuffer[Import]] = buf
       .filter(_.length > 0)
 
     // Remove all newlines within import groups
@@ -69,7 +69,7 @@ class SortImports(config: SortImportsConfig) extends SemanticRule("SortImports")
       // Sort all imports then group based on SortImports rule
       // In case of import list, the first element in the list is significant
       val importsGrouped = importLines
-        .sortWith((line1: Tree, line2: Tree) => {
+        .sortWith((line1, line2) => {
           line1.children.head.toString.compareTo(line2.children.head.toString) < 0
         })
         .groupBy(line => {
@@ -96,7 +96,7 @@ class SortImports(config: SortImportsConfig) extends SemanticRule("SortImports")
       importsSorted.init :+ importsSorted.last.dropRight(1)
     })
 
-    val combined: ListBuffer[ListBuffer[(Tree, String)]] = unsorted
+    val combined: ListBuffer[ListBuffer[(Import, String)]] = unsorted
       .zip(sorted)
       .map(i => i._1.zip(i._2))
 

--- a/scalafix/rules/src/main/scala/fix/Sortimports.scala
+++ b/scalafix/rules/src/main/scala/fix/Sortimports.scala
@@ -49,13 +49,6 @@ class SortImports(config: SortImportsConfig) extends SemanticRule("SortImports")
     // Contains groups of imports
     val unsorted: ListBuffer[ListBuffer[Tree]] = buf
       .filter(_.length > 0)
-      .map(i => {
-        i.map({
-            case x if x.children.size == 1 => x.children
-            case x                         => List(x)
-          })
-          .flatten
-      })
 
     // Remove all newlines within import groups
     val removeLinesPatch: ListBuffer[Patch] = unsorted
@@ -74,12 +67,13 @@ class SortImports(config: SortImportsConfig) extends SemanticRule("SortImports")
     // Sort each group of imports
     val sorted: ListBuffer[ListBuffer[String]] = unsorted.map(importLines => {
       // Sort all imports then group based on SortImports rule
+      // In case of import list, the first element in the list is significant
       val importsGrouped = importLines
-        .sortWith((el1: Tree, el2: Tree) => {
-          el1.toString.compareTo(el2.toString) < 0
+        .sortWith((line1: Tree, line2: Tree) => {
+          line1.children.head.toString.compareTo(line2.children.head.toString) < 0
         })
-        .groupBy(s => {
-          config.blocks.find(p => s.toString.startsWith(p))
+        .groupBy(line => {
+          config.blocks.find(block => line.children.head.toString.startsWith(block))
         })
 
       // If a start is not found in the SortImports rule, add it to the end


### PR DESCRIPTION
Previously `Import` nodes with one children (one `Importer` node) were flattened to to that `Importer` node while `Import` nodes with more children were not. Now there's no flattening. Instead the whole `Import` nodes (essentially import lines) are carried through the processing. 

When sorting and grouping the import lines, the first import element (`Importer` node) in the import line is used as the "key" that determines the the grouping and sorting of the whole line.