### PR TITLE
Convert prefix-blocks to regex

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 SortImports is a simplistic Scalafix rule.
 
-It will organize imports into prefix-blocks and order imports inside those blocks alphabetically.
+It will organize imports into prefix-blocks (regex based) and order imports inside those blocks alphabetically.
 
 For example, these imports
 
@@ -34,7 +34,7 @@ if the blocks from the below _Configuration_ example are used.
 
 **Important**
 sort-imports does not (currently) take into account shadowing.
-It is a faily dumb sorter of imports. If your code is using shadowing, it may end up no longer compiling!
+It is a fairly dumb sorter of imports. If your code is using shadowing, it may end up no longer compiling!
 
 ## Usage
 
@@ -45,9 +45,9 @@ It is a faily dumb sorter of imports. If your code is using shadowing, it may en
 ```
 rule = SortImports
 SortImports.blocks = [
-  "java.",
-  "scala.",
+  "java\\.",
+  "scala\\.",
   "*",
-  "com.sun."
+  "com\\.sun\\."
 ]
 ```

--- a/scalafix/input/src/main/scala/fix/commented.scala
+++ b/scalafix/input/src/main/scala/fix/commented.scala
@@ -4,7 +4,7 @@ rule = SortImports
  "java",
  "scala",
  "*",
- "com.sun"
+ "com\\.sun"
  ]
  */
 import scala.util._ // foobar

--- a/scalafix/input/src/main/scala/fix/nestedimports.scala
+++ b/scalafix/input/src/main/scala/fix/nestedimports.scala
@@ -4,7 +4,7 @@ rule = SortImports
  "java",
  "scala",
  "*",
- "com.sun"
+ "com\\.sun"
  ]
  */
 import scala.util._

--- a/scalafix/input/src/main/scala/fix/nostarinimportorder.scala
+++ b/scalafix/input/src/main/scala/fix/nostarinimportorder.scala
@@ -3,7 +3,7 @@ rule = SortImports
  SortImports.blocks = [
  "java",
  "scala",
- "com.sun"
+ "com\\.sun"
  ]
  */
 import scala.util._

--- a/scalafix/input/src/main/scala/fix/regexgroups.scala
+++ b/scalafix/input/src/main/scala/fix/regexgroups.scala
@@ -1,19 +1,22 @@
 /*
  rule = SortImports
  SortImports.blocks = [
- "java",
- "scala",
+ "(java\\.|com\\.sun)",
+ "(scala|javax)",
  "*",
- "com\\.sun"
+ "com\\.oracle"
  ]
  */
-import scala.util._
+
 import scala.collection._
-import java.util.Map
 import com.oracle.net._
-import com.sun.awt._
+import scala.util._
 import java.math.BigInteger
 
-object SortIntoBlocksNoPackage {
+import javax.naming.Reference
+import org.w3c.dom._
+import java.util.Map
+
+object RegexGroups {
   // Add code that needs fixing here.
 }

--- a/scalafix/input/src/main/scala/fix/sortintoblocks.scala
+++ b/scalafix/input/src/main/scala/fix/sortintoblocks.scala
@@ -4,7 +4,7 @@ rule = SortImports
  "java",
  "scala",
  "*",
- "com.sun"
+ "com\\.sun"
  ]
  */
 package fix

--- a/scalafix/input/src/main/scala/fix/subprefixes.scala
+++ b/scalafix/input/src/main/scala/fix/subprefixes.scala
@@ -11,9 +11,9 @@
 
  rule = SortImports
  SortImports.blocks = [
- "scala."
- "scala.collection."
- "scala.annotation."
+ "scala\\."
+ "scala\\.collection\\."
+ "scala\\.annotation\\."
  ]
  */
 

--- a/scalafix/output/src/main/scala/fix/regexgroups.scala
+++ b/scalafix/output/src/main/scala/fix/regexgroups.scala
@@ -1,0 +1,14 @@
+import java.math.BigInteger
+import java.util.Map
+
+import javax.naming.Reference
+import scala.collection._
+import scala.util._
+
+import org.w3c.dom._
+
+import com.oracle.net._
+
+object RegexGroups {
+  // Add code that needs fixing here.
+}

--- a/scalafix/rules/src/main/scala/fix/Sortimports.scala
+++ b/scalafix/rules/src/main/scala/fix/Sortimports.scala
@@ -92,7 +92,7 @@ class SortImports(config: SortImportsConfig) extends SyntacticRule("SortImports"
           line1.children.head.toString.compareTo(line2.children.head.toString) < 0
         })
         .groupBy(line => {
-          configBlocksByLengthDesc.find(block => line.children.head.toString.startsWith(block))
+          configBlocksByLengthDesc.find(block => line.children.head.toString.matches("^" + block + ".*"))
         })
 
       // If a start is not found in the SortImports rule, add it to the end


### PR DESCRIPTION
@NeQuissimus 
I guess you see now where config is not backward compatible, 
if you have `.` in your config, like `com.sun`, after this is merged you have to escape it java style, e.g. `com\\.sun`
lmk what you think

fixes #16 