### PR TITLE
Respect scalafix:{off, on, ok} annotations - Fixes #37

### DIFF
--- a/input/src/main/scala/fix/scalafixoffon.scala
+++ b/input/src/main/scala/fix/scalafixoffon.scala
@@ -1,0 +1,21 @@
+/*
+rule = SortImports
+ SortImports.blocks = [
+ "java",
+ "scala",
+ "*",
+ "com.sun"
+ ]
+ */
+//scalafix:off
+import scala.util._
+import scala.collection._
+//scalafix:on
+import java.util.Map
+import com.oracle.net._
+import com.sun.awt._
+import java.math.BigInteger
+
+object ScalafixOffOn {
+  // Add code that needs fixing here.
+}

--- a/input/src/main/scala/fix/scalafixok.scala
+++ b/input/src/main/scala/fix/scalafixok.scala
@@ -1,0 +1,19 @@
+/*
+rule = SortImports
+ SortImports.blocks = [
+ "java",
+ "scala",
+ "*",
+ "com.sun"
+ ]
+ */
+import scala.util._
+import scala.collection._
+import java.util.Map //scalafix:ok
+import com.oracle.net._
+import com.sun.awt._
+import java.math.BigInteger
+
+object ScalafixOk {
+  // Add code that needs fixing here.
+}

--- a/output/src/main/scala/fix/scalafixoffon.scala
+++ b/output/src/main/scala/fix/scalafixoffon.scala
@@ -1,0 +1,12 @@
+//scalafix:off
+import scala.util._
+import scala.collection._
+//scalafix:on
+import java.util.Map
+import com.oracle.net._
+import com.sun.awt._
+import java.math.BigInteger
+
+object ScalafixOffOn {
+  // Add code that needs fixing here.
+}

--- a/output/src/main/scala/fix/scalafixok.scala
+++ b/output/src/main/scala/fix/scalafixok.scala
@@ -1,0 +1,10 @@
+import scala.util._
+import scala.collection._
+import java.util.Map //scalafix:ok
+import com.oracle.net._
+import com.sun.awt._
+import java.math.BigInteger
+
+object ScalafixOk {
+  // Add code that needs fixing here.
+}


### PR DESCRIPTION
This seemed like the easiest way to fix the issue #37, just ignore the rule for that file if any of the imports contain `scalafix:ok` or are in a `scalafix:off` - `scalafix:on` block.