### PR TITLE
add `ThisBuild` scope to dependecy definition

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ It is a faily dumb sorter of imports. If your code is using shadowing, it may en
 
 Latest version: ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/NeQuissimus/sort-imports?sort=semver)
 
-`scalafixDependencies += "com.nequissimus" %% "sort-imports" % "<VERSION>"`
+`ThisBuild / scalafixDependencies += "com.nequissimus" %% "sort-imports" % "<VERSION>"`
 
 ## Configuration
 


### PR DESCRIPTION
I like when things work when I copy and paste, especially if I want try something quickly.

I wanted to give sort-imports a try and I copy paste the things from readme but It did not work. It took me sometime to understand why it does not work. It looks like that we need `ThisBuild` to be able to use the rule and everyone seem to be using that way already anyway: https://github.com/search?l=Scala&p=1&q=com.nequissimus+sort-imports&type=Code