### PR TITLE
Sort with wildcard and group first, close #47

### DIFF
--- a/input/src/main/scala/fix/asciisort.scala
+++ b/input/src/main/scala/fix/asciisort.scala
@@ -1,0 +1,19 @@
+/*
+rule = SortImports
+ SortImports.blocks = [
+ "java",
+ "scala",
+ "*"
+ ]
+ */
+package fix
+
+import scala._
+import scala.Console._
+
+import java.util.{ Base64, HashMap }
+import java.util.regex.Matcher
+
+object AsciiSort {
+  // Add code that needs fixing here.
+}

--- a/input/src/main/scala/fix/commented.scala
+++ b/input/src/main/scala/fix/commented.scala
@@ -7,11 +7,11 @@ rule = SortImports
  "com.sun"
  ]
  */
-import scala.util._ // foobar
+import scala.util._
 import scala.collection._
-import java.util.Map
+import java.util.Map // foo1
 import com.oracle.net._
-import com.sun.awt._
+import com.sun.awt._ // foo2
 import java.math.BigInteger
 
 /**

--- a/input/src/main/scala/fix/nonasciisort.scala
+++ b/input/src/main/scala/fix/nonasciisort.scala
@@ -1,0 +1,20 @@
+/*
+rule = SortImports
+ SortImports.blocks = [
+ "java",
+ "scala",
+ "*"
+ ]
+ SortImports.asciiSort = false
+ */
+package fix
+
+import scala.Console._
+import scala._
+
+import java.util.regex.Matcher
+import java.util.{ Base64, HashMap }
+
+object NonAsciiSort {
+  // Add code that needs fixing here.
+}

--- a/output/src/main/scala/fix/asciisort.scala
+++ b/output/src/main/scala/fix/asciisort.scala
@@ -1,0 +1,11 @@
+package fix
+
+import java.util.regex.Matcher
+import java.util.{ Base64, HashMap }
+
+import scala.Console._
+import scala._
+
+object AsciiSort {
+  // Add code that needs fixing here.
+}

--- a/output/src/main/scala/fix/commented.scala
+++ b/output/src/main/scala/fix/commented.scala
@@ -1,12 +1,12 @@
 import java.math.BigInteger
-import java.util.Map
+import java.util.Map // foo1
 
 import scala.collection._
-import scala.util._ // foobar
+import scala.util._
 
 import com.oracle.net._
 
-import com.sun.awt._
+import com.sun.awt._ // foo2
 
 /**
  *  Bla

--- a/output/src/main/scala/fix/nonasciisort.scala
+++ b/output/src/main/scala/fix/nonasciisort.scala
@@ -1,0 +1,11 @@
+package fix
+
+import java.util.{ Base64, HashMap }
+import java.util.regex.Matcher
+
+import scala._
+import scala.Console._
+
+object NonAsciiSort {
+  // Add code that needs fixing here.
+}

--- a/rules/src/main/scala/fix/ImportGroup.scala
+++ b/rules/src/main/scala/fix/ImportGroup.scala
@@ -1,0 +1,57 @@
+package fix
+
+import scala.collection.mutable.ListBuffer
+import scala.meta.contrib.AssociatedComments
+import scala.meta.inputs.Position
+import scala.meta.tokens.Token
+import scala.meta.{ Import, Traverser, Tree }
+
+object ImportGroupTraverser {
+  def retrieveImportGroups(tree: Tree): List[ImportGroup] = {
+    val importGroupsBuffer = ListBuffer[ListBuffer[Import]](ListBuffer.empty)
+    val importTraverser    = new ImportGroupTraverser(importGroupsBuffer)
+    importTraverser(tree)
+    importGroupsBuffer.map(importGroupBuffer => ImportGroup(importGroupBuffer.toList)).toList
+  }
+}
+
+private class ImportGroupTraverser(listBuffer: ListBuffer[ListBuffer[Import]]) extends Traverser {
+  override def apply(tree: Tree): Unit = tree match {
+    case x: Import => listBuffer.last.append(x)
+    case node =>
+      listBuffer.append(ListBuffer.empty)
+      super.apply(node)
+  }
+}
+
+object ImportGroup {
+
+  val empty: ImportGroup = ImportGroup(Nil)
+}
+
+case class ImportGroup(value: List[Import]) extends Traversable[Import] {
+
+  def sortWith(ordering: Ordering[Import]): ImportGroup = ImportGroup(value.sortWith(ordering.lt))
+
+  def groupByBlock(blocks: List[String], defaultBlock: String): Map[String, ImportGroup] =
+    value.groupBy { imp =>
+      blocks
+        .find(block => imp.children.head.syntax.startsWith(block))
+        .getOrElse(defaultBlock)
+    }.mapValues(ImportGroup(_))
+
+  def containPosition(pos: Position): Boolean =
+    pos.start > value.head.pos.start && pos.end < value.last.pos.end
+
+  def trailingComment(comments: AssociatedComments): Map[Import, Token.Comment] =
+    value
+      .map(currentImport => currentImport -> comments.trailing(currentImport).headOption)
+      .collect {
+        case (imp, comment) if comment.nonEmpty => (imp, comment.get)
+      }
+      .toMap
+
+  override def nonEmpty: Boolean = value.nonEmpty
+
+  override def foreach[U](f: Import => U): Unit = value.foreach(f)
+}

--- a/rules/src/main/scala/fix/ImportOrdering.scala
+++ b/rules/src/main/scala/fix/ImportOrdering.scala
@@ -1,0 +1,15 @@
+package fix
+
+import scala.meta.Import
+
+sealed trait ImportOrdering extends Ordering[Import] {
+
+  protected def strFirstImport(imp: Import): String =
+    imp.children.head.syntax
+}
+
+class DefaultSort extends ImportOrdering {
+
+  override def compare(x: Import, y: Import): Int =
+    strFirstImport(x).compareTo(strFirstImport(y))
+}

--- a/rules/src/main/scala/fix/ImportOrdering.scala
+++ b/rules/src/main/scala/fix/ImportOrdering.scala
@@ -1,6 +1,7 @@
 package fix
 
 import scala.meta.Import
+import WildcardAndGroupFirstSort._
 
 sealed trait ImportOrdering extends Ordering[Import] {
 
@@ -12,4 +13,25 @@ class DefaultSort extends ImportOrdering {
 
   override def compare(x: Import, y: Import): Int =
     strFirstImport(x).compareTo(strFirstImport(y))
+}
+
+object WildcardAndGroupFirstSort {
+
+  private val wildcardRegex = "_".r
+  private val groupRegex    = "\\{.+\\}".r
+}
+
+class WildcardAndGroupFirstSort extends ImportOrdering {
+
+  private def transformForSorting(imp: Import): (String, String) = {
+    val strImp = strFirstImport(imp)
+    (strImp, groupRegex.replaceAllIn(wildcardRegex.replaceAllIn(strImp, "\0"), "\1"))
+  }
+
+  override def compare(x: Import, y: Import): Int =
+    (transformForSorting(x), transformForSorting(y)) match {
+      case ((strImp1, tranformedStrImp1), (strImp2, tranformedStrImp2)) =>
+        val transformComparison = tranformedStrImp1.compareTo(tranformedStrImp2)
+        if (transformComparison != 0) transformComparison else strImp1.compareTo(strImp2)
+    }
 }

--- a/rules/src/main/scala/fix/Sortimports.scala
+++ b/rules/src/main/scala/fix/Sortimports.scala
@@ -9,7 +9,8 @@ import metaconfig.{ generic, ConfDecoder, ConfEncoder, Configured }
 import scalafix.v1._
 
 final case class SortImportsConfig(
-  blocks: List[String] = List(SortImportsConfig.Blocks.Asterisk)
+  blocks: List[String] = List(SortImportsConfig.Blocks.Asterisk),
+  asciiSort: Boolean = true
 )
 
 object SortImportsConfig {
@@ -41,7 +42,8 @@ class SortImports(config: SortImportsConfig) extends SyntacticRule("SortImports"
       .getOrElse("SortImports")(this.config)
       .map(new SortImports(_))
 
-  private val importOrdering: ImportOrdering = new DefaultSort
+  private val importOrdering: ImportOrdering =
+    if (config.asciiSort) new DefaultSort else new WildcardAndGroupFirstSort
 
   override def fix(implicit doc: SyntacticDocument): Patch = {
 


### PR DESCRIPTION
[Issue 47](https://github.com/NeQuissimus/sort-imports/issues/47)

**Motivation:** 

Basically, ASCII sort order is the standard in the Java world (from Google's style guide).

However, this works well in Java where the wildcard is * that comes in the ASCII table before alphanums. In Scala, the wildcard is _ and Scala has grouped imports.

**Modifications**:

_Refactoring_
- `ImportGroup` abstract `List[Import]` and operations on it
- Use `List` instead of `ListBuffer` when possible
- Rename variables for better comprehension
- Sort implementation abstract by `Ordering[Import]`

_Feature_ 
- Add **asciiSort boolean** in **configuration** allowing using new sorting by turning **false** (default to **true**)
- Add **SortWith** implementation handling the expected sorting

_Fix_
- Don't keep only last comment of imports

**Result:**
```
// input  SortImports.asciiSort = false
import scala.Console._
import scala._

import java.util.regex.Matcher
import java.util.{ HashMap, Base64 }
```

```
// ouput  SortImports.asciiSort = false
import java.util.{ HashMap, Base64 }
import java.util.regex.Matcher

import scala._
import scala.Console._

```