### PR TITLE
Fix loses of input formatting, close #52

### DIFF
--- a/rules/src/main/scala/fix/Sortimports.scala
+++ b/rules/src/main/scala/fix/Sortimports.scala
@@ -97,9 +97,7 @@ class SortImports(config: SortImportsConfig) extends SyntacticRule("SortImports"
             case (block, _) => block == configBlock
           }.fold(acc) {
             case (_, imports) =>
-              val strImports = imports.map { imp =>
-                comments.get(imp).fold(imp.syntax)(comment => s"${imp.syntax} ${comment.syntax}")
-              }.toSeq
+              val strImports = imports.map(imp => comments.get(imp).fold(s"$imp")(comment => s"$imp $comment")).toSeq
 
               acc :+ (strImports.init :+ (strImports.last + '\n'))
           }


### PR DESCRIPTION
Using `syntax `instead of `toString` loses input formatting.