### PR TITLE
Introduce support for regex based groups

### DIFF
--- a/input/src/main/scala/fix/regex.scala
+++ b/input/src/main/scala/fix/regex.scala
@@ -1,0 +1,23 @@
+/*
+ rule = SortImports
+ SortImports.blocks = [
+ "re:javax?\\.",
+ "scala"
+ ]
+ */
+import java.math.BigInteger
+import java.util.Map
+
+import scala.collection._
+import scala.util._
+
+import javax.net.ssl.SSLEngine
+import foo.Bar
+
+object Regex {
+  // Add code that needs fixing here.
+}
+
+package foo {
+  object Bar
+}

--- a/input/src/main/scala/fix/regexoverlapping.scala
+++ b/input/src/main/scala/fix/regexoverlapping.scala
@@ -1,0 +1,14 @@
+/*
+ rule = SortImports
+ SortImports.blocks = [
+ "re:java.*",
+ "re:javax.*"
+ ]
+ */
+import javax.net.ssl.SSLEngine
+import java.math.BigInteger
+import java.util.Map
+
+object RegexOverlapping {
+  // Add code that needs fixing here.
+}

--- a/output/src/main/scala/fix/regex.scala
+++ b/output/src/main/scala/fix/regex.scala
@@ -1,0 +1,16 @@
+import java.math.BigInteger
+import java.util.Map
+import javax.net.ssl.SSLEngine
+
+import scala.collection._
+import scala.util._
+
+import foo.Bar
+
+object Regex {
+  // Add code that needs fixing here.
+}
+
+package foo {
+  object Bar
+}

--- a/output/src/main/scala/fix/regexoverlapping.scala
+++ b/output/src/main/scala/fix/regexoverlapping.scala
@@ -1,0 +1,8 @@
+import java.math.BigInteger
+import java.util.Map
+
+import javax.net.ssl.SSLEngine
+
+object RegexOverlapping {
+  // Add code that needs fixing here.
+}

--- a/rules/src/main/scala/fix/Block.scala
+++ b/rules/src/main/scala/fix/Block.scala
@@ -1,0 +1,24 @@
+package fix
+
+import java.util.regex.Pattern
+
+sealed trait Block {
+  def string: String
+  def matches(s: String): Boolean
+}
+object Block {
+  final class StaticPrefix(val string: String) extends Block {
+    override def matches(s: String): Boolean = s.startsWith(string)
+  }
+  object RegexPrefix {
+    val Prefix: String = "re:"
+  }
+  final class RegexPrefix(val string: String) extends Block {
+    private val pattern                      = Pattern.compile(string)
+    override def matches(s: String): Boolean = pattern.matcher(s).lookingAt
+  }
+  object Default extends Block {
+    val string                               = "*"
+    override def matches(s: String): Boolean = true
+  }
+}

--- a/rules/src/main/scala/fix/ImportGroup.scala
+++ b/rules/src/main/scala/fix/ImportGroup.scala
@@ -24,20 +24,15 @@ private class ImportGroupTraverser(listBuffer: ListBuffer[ListBuffer[Import]]) e
   }
 }
 
-object ImportGroup {
-
-  val empty: ImportGroup = ImportGroup(Nil)
-}
-
 case class ImportGroup(value: List[Import]) extends Traversable[Import] {
 
   def sortWith(ordering: Ordering[Import]): ImportGroup = ImportGroup(value.sortWith(ordering.lt))
 
-  def groupByBlock(blocks: List[String], defaultBlock: String): Map[String, ImportGroup] =
+  def groupByBlock(blocks: List[Block]): Map[Block, ImportGroup] =
     value.groupBy { imp =>
       blocks
-        .find(block => imp.children.head.syntax.startsWith(block))
-        .getOrElse(defaultBlock)
+        .find(_.matches(imp.children.head.syntax))
+        .getOrElse(Block.Default)
     }.mapValues(ImportGroup(_))
 
   def containPosition(pos: Position): Boolean =

--- a/rules/src/main/scala/fix/ImportOrdering.scala
+++ b/rules/src/main/scala/fix/ImportOrdering.scala
@@ -17,15 +17,15 @@ class DefaultSort extends ImportOrdering {
 
 object WildcardAndGroupFirstSort {
 
-  private val wildcardRegex = "_".r
-  private val groupRegex    = "\\{.+\\}".r
+  private val wildcardRegex = "\\._".r
+  private val groupRegex    = "\\.\\{".r
 }
 
 class WildcardAndGroupFirstSort extends ImportOrdering {
 
   private def transformForSorting(imp: Import): (String, String) = {
     val strImp = strFirstImport(imp)
-    (strImp, groupRegex.replaceAllIn(wildcardRegex.replaceAllIn(strImp, "\0"), "\1"))
+    (strImp, groupRegex.replaceAllIn(wildcardRegex.replaceAllIn(strImp, ".\0"), ".\1"))
   }
 
   override def compare(x: Import, y: Import): Int =


### PR DESCRIPTION
Introduce support for regex based groups

Motivation:

Currently, only static groups are supported. It would be convenient to support regex based groups, eg for grouping `java` and `javax` packages in the same group.

Modifications:

* support the same syntax as scalafix-organize-imports
* Introduce Block type hierarchy
* Fix SortImports file name case

Result:

Regex based groups are now supported