### PR TITLE
Use `org.xml._` instead of `com.oracle.net._`

### DIFF
--- a/input/src/main/scala/fix/commented.scala
+++ b/input/src/main/scala/fix/commented.scala
@@ -10,7 +10,7 @@ rule = SortImports
 import scala.util._
 import scala.collection._
 import java.util.Map // foo1
-import com.oracle.net._
+import org.xml._
 import com.sun.awt._ // foo2
 import java.math.BigInteger
 

--- a/input/src/main/scala/fix/nestedimports.scala
+++ b/input/src/main/scala/fix/nestedimports.scala
@@ -10,7 +10,7 @@ rule = SortImports
 import scala.util._
 import scala.collection._
 import java.util.Map
-import com.oracle.net._
+import org.xml._
 
 object NestedImports {
   import java.math.BigInteger

--- a/input/src/main/scala/fix/nostarinimportorder.scala
+++ b/input/src/main/scala/fix/nostarinimportorder.scala
@@ -9,7 +9,7 @@ rule = SortImports
 import scala.util._
 import scala.collection._
 import java.util.Map
-import com.oracle.net._
+import org.xml._
 
 object NoStarInImportOrder {
   import java.math.BigInteger

--- a/input/src/main/scala/fix/sortintoblocks.scala
+++ b/input/src/main/scala/fix/sortintoblocks.scala
@@ -12,7 +12,7 @@ package fix
 import scala.util._
 import scala.collection._
 import java.util.Map
-import com.oracle.net._
+import org.xml._
 import com.sun.awt._
 import java.math.BigInteger
 

--- a/input/src/main/scala/fix/sortintoblocksnopackage.scala
+++ b/input/src/main/scala/fix/sortintoblocksnopackage.scala
@@ -10,7 +10,7 @@
 import scala.util._
 import scala.collection._
 import java.util.Map
-import com.oracle.net._
+import org.xml._
 import com.sun.awt._
 import java.math.BigInteger
 

--- a/output/src/main/scala/fix/commented.scala
+++ b/output/src/main/scala/fix/commented.scala
@@ -4,7 +4,7 @@ import java.util.Map // foo1
 import scala.collection._
 import scala.util._
 
-import com.oracle.net._
+import org.xml._
 
 import com.sun.awt._ // foo2
 

--- a/output/src/main/scala/fix/nestedimports.scala
+++ b/output/src/main/scala/fix/nestedimports.scala
@@ -3,7 +3,7 @@ import java.util.Map
 import scala.collection._
 import scala.util._
 
-import com.oracle.net._
+import org.xml._
 
 object NestedImports {
   import java.math.BigInteger

--- a/output/src/main/scala/fix/nostarinimportorder.scala
+++ b/output/src/main/scala/fix/nostarinimportorder.scala
@@ -3,7 +3,7 @@ import java.util.Map
 import scala.collection._
 import scala.util._
 
-import com.oracle.net._
+import org.xml._
 
 object NoStarInImportOrder {
   import java.math.BigInteger

--- a/output/src/main/scala/fix/sortintoblocks.scala
+++ b/output/src/main/scala/fix/sortintoblocks.scala
@@ -6,7 +6,7 @@ import java.util.Map
 import scala.collection._
 import scala.util._
 
-import com.oracle.net._
+import org.xml._
 
 import com.sun.awt._
 

--- a/output/src/main/scala/fix/sortintoblocksnopackage.scala
+++ b/output/src/main/scala/fix/sortintoblocksnopackage.scala
@@ -4,7 +4,7 @@ import java.util.Map
 import scala.collection._
 import scala.util._
 
-import com.oracle.net._
+import org.xml._
 
 import com.sun.awt._
 

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ For example, these imports
 import scala.util._
 import scala.collection._
 import java.util.Map
-import com.oracle.net._
+import org.xml._
 import com.sun._
 ```
 
@@ -35,7 +35,7 @@ import java.util.Map
 import scala.collection._
 import scala.util._
 
-import com.oracle.net._
+import org.xml._
 
 import com.sun._
 ```


### PR DESCRIPTION
Motivation: I was trying to upgrade scalafix to 0.9.33 an got compilation errors, as my graalvm doesn't have `com.oracle.net`