### PR TITLE
Update scalafix to 0.10.4

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,17 +1,25 @@
+queue_rules:
+  - name: default
+    conditions:
+      - "status-success=build"
+      - "#approved-reviews-by>=1"
+  - name: scala-steward
+    conditions:
+      - "status-success=build"
+
 pull_request_rules:
   - name: Automatic merge
     conditions:
       - base=master
-      - "#approved-reviews-by>=1"
-      - "status-success=build"
     actions:
-      merge:
-        strict: true
+      queue:
+        method: merge
+        name: default
   - name: Merge scala-steward
     conditions:
       - base=master
       - author=scala-steward
-      - "status-success=build"
     actions:
-      merge:
-        strict: true
+      queue:
+        method: merge
+        name: scala-steward

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,17 +1,21 @@
-version = 2.6.4
+version = 3.7.1
+runner.dialect = scala212
+
 maxColumn = 120
-align.multiline = false
-align.preset = most
+align {
+  multiline = false
+  preset = most
+}
 continuationIndent.defnSite = 2
 assumeStandardLibraryStripMargin = true
-docstrings = JavaDoc
+docstrings.style = Asterisk // Like the JavaDoc convention
 lineEndings = preserve
 includeCurlyBraceInSelectChains = false
 danglingParentheses.preset = true
-spaces {
-  inImportCurlyBraces = true
-}
+spaces.inImportCurlyBraces = true
 optIn.annotationNewlines = true
 
-rewrite.rules = [SortImports, RedundantBraces]
-rewrite.redundantBraces.generalExpressions = false
+rewrite {
+  rules = [SortImports, RedundantBraces]
+  redundantBraces.generalExpressions = false
+}

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ inThisBuild(
   )
 )
 
-skip in publish := true
+publish / skip := true
 
 lazy val rules = project.settings(
   moduleName := "sort-imports",
@@ -38,25 +38,25 @@ lazy val rules = project.settings(
 )
 
 lazy val input = project.settings(
-  skip in publish := true
+  publish / skip := true
 )
 
 lazy val output = project.settings(
-  skip in publish := true
+  publish / skip := true
 )
 
 lazy val tests = project
   .settings(
-    skip in publish := true,
+    publish / skip := true,
     libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
-    compile.in(Compile) :=
-      compile.in(Compile).dependsOn(compile.in(input, Compile)).value,
+    Compile / compile :=
+      (Compile / compile).dependsOn(input / Compile / compile).value,
     scalafixTestkitOutputSourceDirectories :=
-      sourceDirectories.in(output, Compile).value,
+      (output / Compile / sourceDirectories).value,
     scalafixTestkitInputSourceDirectories :=
-      sourceDirectories.in(input, Compile).value,
+      (input / Compile / sourceDirectories).value,
     scalafixTestkitInputClasspath :=
-      fullClasspath.in(input, Compile).value
+      (input / Compile / fullClasspath).value
   )
   .dependsOn(rules)
   .enablePlugins(ScalafixTestkitPlugin)

--- a/input/src/main/scala/fix/commented.scala
+++ b/input/src/main/scala/fix/commented.scala
@@ -15,7 +15,7 @@ import com.sun.awt._ // foo2
 import java.math.BigInteger
 
 /**
- *  Bla
+ * Bla
  */
 object Bla {
   val foo = "Hello" // World

--- a/output/src/main/scala/fix/commented.scala
+++ b/output/src/main/scala/fix/commented.scala
@@ -9,7 +9,7 @@ import org.xml._
 import com.sun.awt._ // foo2
 
 /**
- *  Bla
+ * Bla
  */
 object Bla {
   val foo = "Hello" // World

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += Resolver.sonatypeRepo("releases")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"      % "0.9.33")
 addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.1")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt"      % "2.4.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt"      % "2.5.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"      % "0.9.33")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"      % "0.10.4")
 addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"      % "2.5.0")

--- a/rules/src/main/scala/fix/ImportGroup.scala
+++ b/rules/src/main/scala/fix/ImportGroup.scala
@@ -50,8 +50,8 @@ case class ImportGroup(value: List[Import]) extends Iterable[Import] {
       val cs: IndexedSeq[List[Token.Comment]] = sc.flatMap(s => trailingMap.get(s))
 
       (currentImport -> comments.trailing(currentImport).headOption) +: cs.map(c => currentImport -> c.headOption)
-    }.collect {
-      case (imp, Some(comment)) => (imp, comment)
+    }.collect { case (imp, Some(comment)) =>
+      (imp, comment)
     }.toMap
   }
 

--- a/rules/src/main/scala/fix/SortImports.scala
+++ b/rules/src/main/scala/fix/SortImports.scala
@@ -69,11 +69,10 @@ class SortImports(config: SortImportsConfig) extends SyntacticRule("SortImports"
 
     // Remove comments and whitespace between imports and comments
     val removeCommentsPatch: Iterable[Patch] = comments.values.map(Patch.removeToken)
-    val removeCommentSpacesPatch: Iterable[Patch] = comments.flatMap {
-      case (imp, comment) =>
-        (0 to comment.pos.start - imp.pos.end).map { diff =>
-          new Token.Space(Input.None, comment.dialect, imp.pos.end + diff)
-        }
+    val removeCommentSpacesPatch: Iterable[Patch] = comments.flatMap { case (imp, comment) =>
+      (0 to comment.pos.start - imp.pos.end).map { diff =>
+        new Token.Space(Input.None, comment.dialect, imp.pos.end + diff)
+      }
     }.map(Patch.removeToken)
 
     val configBlocks = {
@@ -127,8 +126,8 @@ class SortImports(config: SortImportsConfig) extends SyntacticRule("SortImports"
     val combined: List[List[Swap]] =
       importGroups
         .zip(sorted)
-        .map {
-          case (importGroup, strImportGroupSorted) => importGroup.value.zip(strImportGroupSorted).map(new Swap(_))
+        .map { case (importGroup, strImportGroupSorted) =>
+          importGroup.value.zip(strImportGroupSorted).map(new Swap(_))
         }
 
     // Create patches using sorted - unsorted pairs


### PR DESCRIPTION
When using this plugin on a build using the latest scalafix version, we get a warning that rules were compiled with an obsolete version. In practice the update doesn't seem to make a difference to the features used here, but updating avoids the warning.

I also included:
- updated scalafmt (required a couple config changes and fixed a couple formatting issues)
- an attempt to fix the mergify config as strict mode has been removed after being deprecated (https://blog.mergify.com/strict-mode-deprecation/)